### PR TITLE
fix(sec): upgrade hyperkitty to 1.3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ gunicorn=20.0.0
 homeassistant=0.56
 html5lib=1.0b1
 httplib2=0
-hyperkitty=0
+hyperkitty=1.3.5


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in hyperkitty 0
- [CVE-2021-33038](https://www.oscs1024.com/hd/CVE-2021-33038)


### What did I do？
Upgrade hyperkitty from 0 to 1.3.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS