### PR TITLE
fix(sec): upgrade salt to 3004.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.18.5
 opencv-python>=4.1.1
 
 twisted=11.1.0
-salt=2018.0
+salt=3004.2
 cfscrape=1.6.6
 salt=2018.0.0
 plone=5.0a1


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in salt 2018.0
- [CVE-2022-2282](https://www.oscs1024.com/hd/CVE-2022-2282)


### What did I do？
Upgrade salt from 2018.0 to 3004.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS